### PR TITLE
Add CMR recalculation functionality if purchase line/order is deleted

### DIFF
--- a/src/server/api/routers/purchaseLines.ts
+++ b/src/server/api/routers/purchaseLines.ts
@@ -359,8 +359,24 @@ export const purchaseLinesRouter = createTRPCRouter({
               inventoryCount: true,
             },
           },
+          purchaseOrder: {
+            include: {
+              vendor: {
+                select: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+          },
         },
       });
+      if (!currentPurchaseLine) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `No purchase line found with id '${id}'`,
+        });
+      }
 
       const purchasedCount = currentPurchaseLine?.quantity ?? 0;
 
@@ -377,12 +393,6 @@ export const purchaseLinesRouter = createTRPCRouter({
       const purchaseLine = await prisma.purchaseLine.delete({
         where: { id },
       });
-      // const purchaseLine = await prisma.purchaseLine.update({
-      //   where: { id },
-      //   data: {
-      //     display: false,
-      //   },
-      // });
       if (!purchaseLine) {
         throw new TRPCError({
           code: "NOT_FOUND",
@@ -390,8 +400,10 @@ export const purchaseLinesRouter = createTRPCRouter({
         });
       }
 
+      const currentBookId = currentPurchaseLine.bookId;
+      const currentVendorId = currentPurchaseLine.purchaseOrder.vendorId;
       await prisma.book.update({
-        where: { id: currentPurchaseLine?.book.id },
+        where: { id: currentBookId },
         data: {
           inventoryCount: {
             decrement: purchasedCount,
@@ -399,7 +411,79 @@ export const purchaseLinesRouter = createTRPCRouter({
         },
       });
 
-      return purchaseLine;
+      // Check if this was part of cost-most-recent for this book and vendor combination
+      const costMostRecentVendor = await prisma.costMostRecentVendor.findUnique(
+        {
+          where: {
+            costMostRecentVendorId: {
+              bookId: currentBookId,
+              vendorId: currentVendorId,
+            },
+          },
+          include: {
+            purchaseLine: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        }
+      );
+
+      if (costMostRecentVendor?.purchaseLineId !== currentPurchaseLine.id) {
+        return purchaseLine; // CMR is not affected
+      } else {
+        // need to recompute CMR
+        const mostRecentPurchaseLine = await prisma.purchaseLine.findFirst({
+          where: {
+            bookId: currentBookId,
+            purchaseOrder: {
+              vendor: {
+                id: currentVendorId,
+              },
+            },
+          },
+          orderBy: {
+            purchaseOrder: {
+              date: "desc",
+            },
+          },
+        });
+
+        if (!mostRecentPurchaseLine) {
+          await prisma.costMostRecentVendor.delete({
+            where: {
+              costMostRecentVendorId: {
+                bookId: currentBookId,
+                vendorId: currentVendorId,
+              },
+            },
+          });
+          return purchaseLine;
+        } else {
+          await prisma.costMostRecentVendor.update({
+            where: {
+              costMostRecentVendorId: {
+                bookId: currentBookId,
+                vendorId: currentVendorId,
+              },
+            },
+            data: {
+              purchaseLine: {
+                connect: {
+                  id: mostRecentPurchaseLine.id,
+                },
+              },
+              purchaseOrder: {
+                connect: {
+                  id: mostRecentPurchaseLine.purchaseOrderId,
+                },
+              },
+            },
+          });
+        }
+        return purchaseLine;
+      }
     }),
 
   getSecretMessage: protectedProcedure.query(() => {

--- a/src/server/api/routers/purchaseOrders.ts
+++ b/src/server/api/routers/purchaseOrders.ts
@@ -691,26 +691,40 @@ export const purchaseOrdersRouter = createTRPCRouter({
               },
             },
           },
+          vendor: { select: { id: true, name: true } },
         },
       });
 
-      for (const purchaseLine of currentPurchaseOrder?.purchaseLines ?? []) {
-        const purchasedCount = purchaseLine?.quantity ?? 0;
-        const bookInventoryCount = purchaseLine?.book.inventoryCount ?? 100000;
+      if (!currentPurchaseOrder) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `No purchase order to delete with id '${id}'`,
+        });
+      }
+
+      const deletedPurchaseOrder = await prisma.purchaseOrder.delete({
+        where: { id },
+      });
+      if (!deletedPurchaseOrder) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `No purchase order to delete with id '${id}'`,
+        });
+      }
+
+      for (const currentPurchaseLine of currentPurchaseOrder.purchaseLines ??
+        []) {
+        const purchasedCount = currentPurchaseLine?.quantity ?? 0;
+        const bookInventoryCount =
+          currentPurchaseLine?.book.inventoryCount ?? 100000;
         if (bookInventoryCount < purchasedCount) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message: `Cannot delete purchase order of ${purchasedCount} boks`,
           });
         }
-        // const deletedPurchaseLine = await prisma.purchaseLine.update({
-        //   where: { id: purchaseLine.id },
-        //   data: {
-        //     display: false,
-        //   },
-        // });
         const deletedPurchaseLine = await prisma.purchaseLine.delete({
-          where: { id: purchaseLine.id },
+          where: { id: currentPurchaseLine.id },
         });
         if (!deletedPurchaseLine) {
           throw new TRPCError({
@@ -719,31 +733,90 @@ export const purchaseOrdersRouter = createTRPCRouter({
           });
         }
         await prisma.book.update({
-          where: { id: purchaseLine?.book.id },
+          where: { id: currentPurchaseLine?.book.id },
           data: {
             inventoryCount: {
               decrement: purchasedCount,
             },
           },
         });
-      }
 
-      // const purchaseOrder = await prisma.purchaseOrder.update({
-      //   where: { id },
-      //   data: {
-      //     display: false,
-      //   },
-      // });
-      const purchaseOrder = await prisma.purchaseOrder.delete({
-        where: { id },
-      });
-      if (!purchaseOrder) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `No purchase order to delete with id '${id}'`,
-        });
+        const currentBookId = currentPurchaseLine.bookId;
+        const currentVendorId = currentPurchaseOrder.vendorId;
+
+        // Check if this purchase line was part of cost-most-recent for this book and vendor combination
+        const costMostRecentVendor =
+          await prisma.costMostRecentVendor.findUnique({
+            where: {
+              costMostRecentVendorId: {
+                bookId: currentBookId,
+                vendorId: currentVendorId,
+              },
+            },
+            include: {
+              purchaseLine: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          });
+
+        if (costMostRecentVendor?.purchaseLineId !== currentPurchaseLine.id) {
+          continue; // CMR is not affected
+        } else {
+          // need to recompute CMR
+          const mostRecentPurchaseLine = await prisma.purchaseLine.findFirst({
+            where: {
+              bookId: currentBookId,
+              purchaseOrder: {
+                vendor: {
+                  id: currentVendorId,
+                },
+              },
+            },
+            orderBy: {
+              purchaseOrder: {
+                date: "desc",
+              },
+            },
+          });
+
+          if (!mostRecentPurchaseLine) {
+            await prisma.costMostRecentVendor.delete({
+              where: {
+                costMostRecentVendorId: {
+                  bookId: currentBookId,
+                  vendorId: currentVendorId,
+                },
+              },
+            });
+            continue;
+          } else {
+            await prisma.costMostRecentVendor.update({
+              where: {
+                costMostRecentVendorId: {
+                  bookId: currentBookId,
+                  vendorId: currentVendorId,
+                },
+              },
+              data: {
+                purchaseLine: {
+                  connect: {
+                    id: mostRecentPurchaseLine.id,
+                  },
+                },
+                purchaseOrder: {
+                  connect: {
+                    id: mostRecentPurchaseLine.purchaseOrderId,
+                  },
+                },
+              },
+            });
+          }
+        }
+        return deletedPurchaseOrder;
       }
-      return purchaseOrder;
     }),
 
   getSecretMessage: protectedProcedure.query(() => {


### PR DESCRIPTION
# Description
<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
CMR needs to be recalculating if a purchase line/order is deleted since it might affect the current CMR. 

Fixes # (issue)

## Type of change

<!--- Please delete options that are not relevant. --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Needs Work
<!--- Anything that remains to be improved or fixed -->

#Sample
<!--- Include a sample for frontend work particularly --->
